### PR TITLE
Make this behave more like through2.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function makeCtor(options, transform) {
 
 	function doTransform(chunk, encoding, callback) {
 		var stream = this;
-		Promise.resolve(chunk).then(transform).then(function (result) {
+		Promise.resolve(chunk).then(transform.bind(stream)).then(function (result) {
 			callback(null, result);
 		}).catch(callback);
 	}

--- a/index.js
+++ b/index.js
@@ -35,8 +35,7 @@ function makeCtor(options, transform) {
 	function doTransform(chunk, encoding, callback) {
 		var stream = this;
 		Promise.resolve(chunk).then(transform).then(function (result) {
-			stream.push(result);
-			callback(null);
+			callback(null, result);
 		}).catch(callback);
 	}
 }

--- a/test/index.js
+++ b/test/index.js
@@ -66,3 +66,22 @@ test("throwing", function (t) {
 
 	spigot(["hello", "world"]).pipe(stream).pipe(concat(confirm));
 });
+
+// Tests scenario from in https://github.com/RangerMauve/through2-map-promise/issues/2
+test("unpiped", function (t) {
+	var VALUES = 100;
+	var data = [];
+	var i = VALUES;
+	while(i--) data.push(i);
+
+	var seen = 0;
+	var out = throughPromise.obj(function(item) {seen++;});
+
+	out.on('finish', function() {
+		t.equal(seen, VALUES, "expected " + VALUES + " results");
+		t.end();
+	});
+
+	spigot({objectMode: true}, data)
+	.pipe(out);
+});


### PR DESCRIPTION
This fixes the issue in #2, and makes through2-map-promise behave the same as through2 when not piping to another stream.  This comes at a slightly cost, though, because it also subtly changes the behavior of through2-map-promise;

```js
var toArray = require('stream-to-array');
var spigot = require("stream-spigot");
var throughPromise = require("through2-map-promise");

var data = [];
var i = 10;
while(i--) data.push(i);

var seen = 0;
var out = throughPromise.obj(function(item) {seen++;});

out.on('finish', function() {
    toArray(out, (err, result) => {console.log(result);});
});

spigot({objectMode: true}, data)
.pipe(out);

```

So this pipes 10 numbers into a through2-map-promise, converts the output of `throughPromise` into an array, and prints it.  Without this change, the printed array would be 10 "undefined"s.  With this change, it's just an empty array.  If you change the above to:

    var out = throughPromise.obj(function(item) {return seen++;});

you get the array `[ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]` either way.

If you really want an array of 10 `undefined`s, you can now also do:

    var out = throughPromise.obj(function(item) {this.push(undefined);});

exactly like you would if this were a through2 stream.  This is because we now bind the transform function to the stream, like through2 does.

